### PR TITLE
Improve website task tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# decision-playbook
+# Decision Playbook Website
+
+This repository contains a minimal interactive website located in the `web/` folder. Open `index.html` in a browser to try it.
+
+The page lets you:
+
+- Read a short summary of the playbook.
+- Add, remove, or complete daily action items (stored in your browser).
+- Reset to a set of default tasks inspired by the playbook.
+- See a progress bar showing completion percentage.
+
+The site is intentionally simple so it can run without a server. Open `web/index.html` in any modern browser to get started. Your tasks are saved locally, so no network is required.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Precision Mind Playbook</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>The Precision Mind Playbook</h1>
+        <p>Daily engagement site to help you put the playbook into action.</p>
+    </header>
+    <main>
+        <section id="overview">
+            <h2>Overview</h2>
+            <p>This site summarizes key ideas from the playbook and helps you track daily drills.</p>
+            <button id="toggleSummary">Show/Hide Summary</button>
+            <div id="summary" class="hidden">
+                <p>Use the Clarity Builder to craft your Life North Star, apply mental models like the OODA Loop and First Principles, and practice Socratic questioning. Each day, execute quick drills to review your North Star, set priorities, and reflect on progress.</p>
+            </div>
+        </section>
+        <section id="daily">
+            <h2>Today's Actions</h2>
+            <ul id="taskList"></ul>
+            <div class="buttons">
+                <button id="addTask">Add Task</button>
+                <button id="resetTasks">Reset</button>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>Stay consistent. Review your progress below.</p>
+        <progress id="progressBar" value="0" max="100"></progress>
+        <div id="progress"></div>
+    </footer>
+<script src="script.js"></script>
+</body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,85 @@
+(function() {
+    const summary = document.getElementById('summary');
+    const toggleSummary = document.getElementById('toggleSummary');
+    const taskList = document.getElementById('taskList');
+    const addTaskBtn = document.getElementById('addTask');
+    const resetBtn = document.getElementById('resetTasks');
+    const progressDiv = document.getElementById('progress');
+    const progressBar = document.getElementById('progressBar');
+
+    toggleSummary.addEventListener('click', () => {
+        summary.classList.toggle('hidden');
+    });
+
+    const defaultTasks = [
+        {text: 'Review Life North Star', done: false},
+        {text: 'Set MITs for the day', done: false},
+        {text: 'Evening reflection journal', done: false}
+    ];
+
+    function loadTasks() {
+        let tasks = JSON.parse(localStorage.getItem('tasks') || 'null');
+        if(!tasks) {
+            tasks = defaultTasks;
+            saveTasks(tasks);
+        }
+        taskList.innerHTML = '';
+        tasks.forEach((t, index) => {
+            const li = document.createElement('li');
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.checked = t.done;
+            cb.addEventListener('change', () => {
+                tasks[index].done = cb.checked;
+                saveTasks(tasks);
+                updateProgress();
+            });
+            const span = document.createElement('span');
+            span.textContent = t.text;
+            const del = document.createElement('button');
+            del.textContent = '✕';
+            del.className = 'delete';
+            del.addEventListener('click', () => {
+                tasks.splice(index,1);
+                saveTasks(tasks);
+                loadTasks();
+            });
+
+            li.appendChild(cb);
+            li.appendChild(span);
+            li.appendChild(del);
+            taskList.appendChild(li);
+        });
+        updateProgress();
+    }
+
+    function saveTasks(tasks) {
+        localStorage.setItem('tasks', JSON.stringify(tasks));
+    }
+
+    addTaskBtn.addEventListener('click', () => {
+        const text = prompt('New task');
+        if(!text) return;
+        const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+        tasks.push({text, done:false});
+        saveTasks(tasks);
+        loadTasks();
+    });
+
+    resetBtn.addEventListener('click', () => {
+        if(confirm('Clear all tasks?')) {
+            saveTasks(defaultTasks.map(t => ({...t, done:false})));
+            loadTasks();
+        }
+    });
+
+    function updateProgress() {
+        const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+        const done = tasks.filter(t => t.done).length;
+        const pct = tasks.length ? Math.round((done / tasks.length) * 100) : 0;
+        progressDiv.textContent = `Completed ${done}/${tasks.length} tasks`;
+        progressBar.value = pct;
+    }
+
+    loadTasks();
+})();

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,48 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    background: #f4f4f4;
+}
+header, footer {
+    background: #333;
+    color: #fff;
+    padding: 10px 20px;
+    text-align: center;
+}
+main {
+    padding: 20px;
+}
+.hidden {
+    display: none;
+}
+#taskList li {
+    list-style: none;
+    margin-bottom: 5px;
+}
+button {
+    margin-top: 5px;
+}
+
+.buttons {
+    margin-top: 5px;
+}
+
+#taskList li span {
+    margin-left: 5px;
+}
+
+#taskList li button.delete {
+    margin-left: 10px;
+    background: transparent;
+    border: none;
+    color: #d00;
+    cursor: pointer;
+}
+
+#progressBar {
+    width: 100%;
+    height: 10px;
+    margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- add buttons to reset and remove tasks with default daily actions
- show progress bar and completion percentage
- tweak styling for delete buttons
- update README to document new features

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683d3ca535308322a3709eeb040e13bd